### PR TITLE
Changed the outcome of skipped tests to PASSED.

### DIFF
--- a/dvaresults
+++ b/dvaresults
@@ -22,7 +22,7 @@ def parse_results(dva_yaml):
                                                 item['test']['name'])
             outcome = item['test']['result'].upper()
             if outcome == 'SKIP':
-                outcome = 'NEEDS_INSPECTION'
+                outcome = 'PASSED'
             results[result_name] = {}
             data = {}
             data.update(item=item['ami'])


### PR DESCRIPTION
This outcome seems to make more sense because tests cases the output of
which is 'skipped' do not actually need inspection. They are skipped
because the test case in question is not applicable to the given instance type,
but that information is not available before executing the test (as opposed to
information available beforehand in the yaml config file), e.g. a SR-IOV network
interface doesn't need to be tested if it's not actually supported on that
particular instance type, but the test needs to check for that first.